### PR TITLE
Sort field arguments

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -10,7 +10,7 @@ interface Character {
   friends: [Character]
 
   \\"\\"\\"The friends of the character exposed as a connection with edges\\"\\"\\"
-  friendsConnection(first: Int, after: ID): FriendsConnection!
+  friendsConnection(after: ID, first: Int): FriendsConnection!
 
   \\"\\"\\"The ID of the character\\"\\"\\"
   id: ID!
@@ -35,7 +35,7 @@ type Droid implements Character {
   friends: [Character]
 
   \\"\\"\\"The friends of the droid exposed as a connection with edges\\"\\"\\"
-  friendsConnection(first: Int, after: ID): FriendsConnection!
+  friendsConnection(after: ID, first: Int): FriendsConnection!
 
   \\"\\"\\"The ID of the droid\\"\\"\\"
   id: ID!
@@ -92,7 +92,7 @@ type Human implements Character {
   friends: [Character]
 
   \\"\\"\\"The friends of the human exposed as a connection with edges\\"\\"\\"
-  friendsConnection(first: Int, after: ID): FriendsConnection!
+  friendsConnection(after: ID, first: Int): FriendsConnection!
 
   \\"\\"\\"Height in the preferred unit, default is meters\\"\\"\\"
   height(unit: LengthUnit = METER): Float

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Command, flags } from "@oclif/command";
 import fs from "fs";
 import { buildClientSchema, printSchema } from "graphql";
 
-import { GraphQLField, GraphQLType } from "./types";
+import { GraphQLField, GraphQLType, GraphQLInputValue } from "./types";
 
 class GraphqlJsonToSdl extends Command {
   static description = "Converts a JSON GraphQL schema to GraphQL SDL.";
@@ -62,6 +62,12 @@ function writeSchema(src: string, out: string) {
 
     type.fields.sort((a: GraphQLField, b: GraphQLField) => {
       return a.name.localeCompare(b.name);
+    });
+
+    type.fields.forEach((field: GraphQLField) => {
+      field.args.sort((a: GraphQLInputValue, b: GraphQLInputValue) => {
+        return a.name.localeCompare(b.name);
+      });
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,4 +5,9 @@ export interface GraphQLType {
 
 export interface GraphQLField {
   readonly name: string;
+  readonly args: GraphQLInputValue[]
+}
+
+export interface GraphQLInputValue {
+  readonly name: string;
 }


### PR DESCRIPTION
Sort GraphQL field arguments to have the same output for the same json schema, considering that the order of field arguments is not important.