### PR TITLE
Sort input fields by name

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -21,9 +21,9 @@ interface Character {
 
 \\"\\"\\"The input object sent when passing in a color\\"\\"\\"
 input ColorInput {
-  red: Int!
-  green: Int!
   blue: Int!
+  green: Int!
+  red: Int!
 }
 
 \\"\\"\\"An autonomous mechanical character in the Star Wars universe\\"\\"\\"
@@ -158,14 +158,14 @@ type Review {
 
 \\"\\"\\"The input object sent when someone is creating a new review\\"\\"\\"
 input ReviewInput {
-  \\"\\"\\"0-5 stars\\"\\"\\"
-  stars: Int!
-
   \\"\\"\\"Comment about the movie, optional\\"\\"\\"
   commentary: String
 
   \\"\\"\\"Favorite color, optional\\"\\"\\"
   favorite_color: ColorInput
+
+  \\"\\"\\"0-5 stars\\"\\"\\"
+  stars: Int!
 }
 
 union SearchResult = Human | Droid | Starship

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface GraphQLType {
   readonly name: string;
   readonly fields: GraphQLField[] | null;
+  readonly inputFields: GraphQLInputField[] | null;
 }
 
 export interface GraphQLField {
@@ -9,5 +10,9 @@ export interface GraphQLField {
 }
 
 export interface GraphQLInputValue {
+  readonly name: string;
+}
+
+export interface GraphQLInputField {
   readonly name: string;
 }


### PR DESCRIPTION
Hi @CDThomas,
this time it is to sort the input fields of the provided schema, in order to make the ouput predictable.

Before:
```graphql
input ColorInput {
  red: Int!
  green: Int!
  blue: Int!
}
```

After:
```graphql
input ColorInput {
  blue: Int!
  green: Int!
  red: Int!
}
```
